### PR TITLE
Add highlight demo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ const { messages, handleInputChange, handleSubmit } = useInstrumentedChat();
 The wrapper injects the required `onToolCall` handler and applies DOM updates in the browser. No configuration is needed for the basic highlight tool.
 
 Additional recipes demonstrating real integrations can be found under the [`cookbook`](./cookbook) directory.
+For a quick demonstration of the highlight tool open [`examples/highlight-demo`](./examples/highlight-demo) with `npm run demo`.
 
 ## Development
 

--- a/examples/highlight-demo/index.html
+++ b/examples/highlight-demo/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Highlight Demo</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    input { margin-right: 8px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module">
+    import { highlightLinks } from '../../dist/index.js';
+
+    const { useState } = React;
+
+    function App() {
+      const [key, setKey] = useState('');
+      const [message, setMessage] = useState('');
+
+      async function handleSubmit() {
+        if (!key) {
+          alert('Enter API key');
+          return;
+        }
+        setMessage('Loading...');
+        try {
+          const res = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + key
+            },
+            body: JSON.stringify({
+              model: 'gpt-3.5-turbo',
+              messages: [{ role: 'user', content: 'Say hello' }]
+            })
+          });
+          const data = await res.json();
+          setMessage(data.choices?.[0]?.message?.content || 'No response');
+          highlightLinks({ path: '/foo' });
+        } catch (err) {
+          setMessage('Request failed: ' + err.message);
+        }
+      }
+
+      return React.createElement(
+        'div',
+        null,
+        React.createElement(
+          'p',
+          null,
+          React.createElement('input', {
+            type: 'password',
+            placeholder: 'OpenAI API Key',
+            value: key,
+            onChange: e => setKey(e.target.value)
+          }),
+          React.createElement(
+            'button',
+            { onClick: handleSubmit },
+            'Send'
+          )
+        ),
+        React.createElement('p', null, message),
+        React.createElement(
+          'p',
+          null,
+          'Some ',
+          React.createElement('a', { href: '/foo' }, 'foo link'),
+          ' and ',
+          React.createElement('a', { href: '/bar' }, 'bar link'),
+          '.'
+        )
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+  </script>
+</body>
+</html>

--- a/examples/highlight-demo/server.js
+++ b/examples/highlight-demo/server.js
@@ -1,0 +1,30 @@
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(import.meta.url), '..');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css'
+};
+
+const server = http.createServer(async (req, res) => {
+  const urlPath = req.url === '/' ? '/index.html' : req.url;
+  try {
+    const filePath = resolve(root, '.' + urlPath);
+    const data = await readFile(filePath);
+    const type = mimeTypes[extname(filePath)] || 'text/plain';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  } catch {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Demo running at http://localhost:3000');
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "node --test"
+    "test": "node --test",
+    "demo": "node examples/highlight-demo/server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add example React page under `examples/highlight-demo`
- include a simple demo server and npm script `npm run demo`
- link the demo from README

## Testing
- `npm test`
- `npm run build`
- `npm run demo`

------
https://chatgpt.com/codex/tasks/task_b_685ec5f47d408329bf144e8049bc084a